### PR TITLE
Fix XSS bug

### DIFF
--- a/vanillatree.js
+++ b/vanillatree.js
@@ -135,7 +135,7 @@
 
 			leaf.appendChild( create( 'a', {
 				className: 'vtree-leaf-label',
-				innerHTML: options.label
+				innerText: options.label
 			}) );
 
 			parentList.appendChild( leaf );


### PR DESCRIPTION
By using innerHTML instead of innerText users can enter a name like `<textarea>` and the branch is then rendered as a textarea, users could even use a <script> tag